### PR TITLE
feat: add currency system and in-game buff shop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Snake 1.0
+# Snake 2.0
 
-A minimal React implementation of Snake as the first milestone.
+A React Snake game with an in-match currency system and buff shop.
 
 ## Features
 
@@ -9,6 +9,12 @@ A minimal React implementation of Snake as the first milestone.
 - Food spawn and snake growth
 - Collision detection (wall + self)
 - Score tracking
+- Money earned from each bean
+- In-game shop with multiple upgrades:
+  - Coin multiplier
+  - Growth packs
+  - Collision shield
+  - Slow-time upgrade
 - Restart button
 
 ## Run

--- a/src/App.css
+++ b/src/App.css
@@ -6,6 +6,7 @@
   --head: #047857;
   --body: #10b981;
   --food: #ef4444;
+  --accent: #0f172a;
 }
 
 * {
@@ -18,29 +19,56 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 12px;
   background: radial-gradient(circle at top, #ffffff, var(--bg));
   color: var(--text);
   font-family: 'Avenir Next', 'Segoe UI', sans-serif;
-  padding: 20px;
+  padding: 24px 20px 28px;
+}
+
+h1,
+h2 {
+  margin: 0;
 }
 
 h1 {
-  margin: 0;
   font-size: 2rem;
+}
+
+h2 {
+  font-size: 1.25rem;
 }
 
 .instructions {
   margin: 0;
+  text-align: center;
 }
 
 .hud {
-  width: min(480px, 100%);
+  width: min(520px, 100%);
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
   font-weight: 600;
+}
+
+.buffs {
+  width: min(520px, 100%);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.buffs > span {
+  border: 1px solid #cbd5e1;
+  background: #f1f5f9;
+  border-radius: 8px;
+  padding: 6px 8px;
+  text-align: center;
+  font-size: 0.9rem;
 }
 
 .game-over {
@@ -48,12 +76,12 @@ h1 {
 }
 
 .board {
-  width: min(480px, 92vw);
+  width: min(520px, 92vw);
   aspect-ratio: 1;
   display: grid;
   grid-template-columns: repeat(20, 1fr);
   grid-template-rows: repeat(20, 1fr);
-  border: 2px solid #1f2937;
+  border: 2px solid var(--accent);
   background: var(--panel);
 }
 
@@ -73,10 +101,60 @@ h1 {
   background: var(--food);
 }
 
+.shop {
+  width: min(520px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.shop-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.shop-item {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  background: #ffffff;
+  color: var(--text);
+  padding: 10px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.shop-item:hover:not(:disabled) {
+  border-color: #0ea5e9;
+  box-shadow: 0 6px 18px rgba(14, 165, 233, 0.16);
+}
+
+.shop-item:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.shop-item__name {
+  font-weight: 700;
+}
+
+.shop-item__desc,
+.shop-item__meta {
+  font-size: 0.85rem;
+}
+
+.shop-item__action {
+  color: #0369a1;
+  font-size: 0.95rem;
+}
+
 .restart {
   border: none;
   border-radius: 8px;
-  background: #1f2937;
+  background: var(--accent);
   color: #ffffff;
   padding: 10px 16px;
   cursor: pointer;
@@ -84,4 +162,14 @@ h1 {
 
 .restart:hover {
   background: #111827;
+}
+
+@media (max-width: 720px) {
+  .shop-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .buffs {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,8 +3,16 @@ import './App.css'
 import {
   DIRECTIONS,
   GRID_SIZE,
+  INITIAL_ECONOMY,
+  MAX_COIN_MULTIPLIER,
+  MAX_SLOW_LEVEL,
+  SHOP_ITEM_IDS,
+  SHOP_ITEMS,
+  canPurchaseItem,
+  getTickMs,
   hasCollision,
   isOppositeDirection,
+  purchaseItem,
   spawnFood,
   stepSnake
 } from './gameUtils'
@@ -15,7 +23,6 @@ const INITIAL_SNAKE = [
   { x: 8, y: 10 }
 ]
 const INITIAL_DIRECTION = DIRECTIONS.ArrowRight
-const TICK_MS = 150
 
 function buildCellMap(snake, food) {
   const map = new Map()
@@ -30,6 +37,30 @@ function buildCellMap(snake, food) {
   return map
 }
 
+function isItemMaxed(economy, itemId) {
+  if (itemId === SHOP_ITEM_IDS.coinMultiplier) {
+    return economy.coinMultiplier >= MAX_COIN_MULTIPLIER
+  }
+
+  if (itemId === SHOP_ITEM_IDS.slowTime) {
+    return economy.slowLevel >= MAX_SLOW_LEVEL
+  }
+
+  return false
+}
+
+function getItemProgress(economy, itemId) {
+  if (itemId === SHOP_ITEM_IDS.coinMultiplier) {
+    return `Lv ${economy.coinMultiplier}/${MAX_COIN_MULTIPLIER}`
+  }
+
+  if (itemId === SHOP_ITEM_IDS.slowTime) {
+    return `Lv ${economy.slowLevel}/${MAX_SLOW_LEVEL}`
+  }
+
+  return 'Repeatable'
+}
+
 function App() {
   const [snake, setSnake] = useState(INITIAL_SNAKE)
   const [direction, setDirection] = useState(INITIAL_DIRECTION)
@@ -37,6 +68,9 @@ function App() {
   const [food, setFood] = useState(() => spawnFood(INITIAL_SNAKE))
   const [score, setScore] = useState(0)
   const [isGameOver, setIsGameOver] = useState(false)
+  const [economy, setEconomy] = useState(INITIAL_ECONOMY)
+
+  const tickMs = useMemo(() => getTickMs(economy.slowLevel), [economy.slowLevel])
 
   useEffect(() => {
     function onKeyDown(event) {
@@ -69,29 +103,40 @@ function App() {
         setDirection(activeDirection)
 
         const currentHead = currentSnake[0]
-        const willEatFood =
-          food &&
-          currentHead.x + activeDirection.x === food.x &&
-          currentHead.y + activeDirection.y === food.y
-
-        const nextSnake = stepSnake(currentSnake, activeDirection, willEatFood)
+        const nextHead = {
+          x: currentHead.x + activeDirection.x,
+          y: currentHead.y + activeDirection.y
+        }
+        const willEatFood = food && nextHead.x === food.x && nextHead.y === food.y
+        const shouldGrow = willEatFood || economy.pendingGrowth > 0
+        const nextSnake = stepSnake(currentSnake, activeDirection, shouldGrow)
 
         if (hasCollision(nextSnake, GRID_SIZE)) {
+          if (economy.shields > 0) {
+            setEconomy((value) => ({ ...value, shields: Math.max(0, value.shields - 1) }))
+            return currentSnake
+          }
+
           setIsGameOver(true)
           return currentSnake
         }
 
+        if (economy.pendingGrowth > 0) {
+          setEconomy((value) => ({ ...value, pendingGrowth: value.pendingGrowth - 1 }))
+        }
+
         if (willEatFood) {
           setScore((value) => value + 1)
+          setEconomy((value) => ({ ...value, money: value.money + value.coinMultiplier }))
           setFood(spawnFood(nextSnake, GRID_SIZE))
         }
 
         return nextSnake
       })
-    }, TICK_MS)
+    }, tickMs)
 
     return () => window.clearInterval(timerId)
-  }, [food, isGameOver, queuedDirection])
+  }, [economy.coinMultiplier, economy.pendingGrowth, economy.shields, food, isGameOver, queuedDirection, tickMs])
 
   const cells = useMemo(() => {
     const map = buildCellMap(snake, food)
@@ -104,22 +149,39 @@ function App() {
     return result
   }, [snake, food])
 
+  function buyItem(itemId) {
+    if (isGameOver) {
+      return
+    }
+
+    setEconomy((value) => purchaseItem(value, itemId))
+  }
+
   function resetGame() {
     setSnake(INITIAL_SNAKE)
     setDirection(INITIAL_DIRECTION)
     setQueuedDirection(INITIAL_DIRECTION)
     setFood(spawnFood(INITIAL_SNAKE, GRID_SIZE))
     setScore(0)
+    setEconomy(INITIAL_ECONOMY)
     setIsGameOver(false)
   }
 
   return (
     <main className="app">
-      <h1>Snake 1.0</h1>
-      <p className="instructions">Use arrow keys or WASD to move.</p>
+      <h1>Snake 2.0</h1>
+      <p className="instructions">Use arrow keys or WASD to move. Buy buffs while playing.</p>
       <div className="hud">
         <span>Score: {score}</span>
+        <span>Money: ${economy.money}</span>
+        <span>Speed: {tickMs}ms</span>
         {isGameOver && <strong className="game-over">Game Over</strong>}
+      </div>
+
+      <div className="buffs" aria-label="active-buffs">
+        <span>Multiplier x{economy.coinMultiplier}</span>
+        <span>Queued Growth {economy.pendingGrowth}</span>
+        <span>Shields {economy.shields}</span>
       </div>
 
       <section className="board" aria-label="snake-board">
@@ -130,6 +192,31 @@ function App() {
             aria-hidden="true"
           />
         ))}
+      </section>
+
+      <section className="shop" aria-label="shop">
+        <h2>Shop</h2>
+        <div className="shop-grid">
+          {SHOP_ITEMS.map((item) => {
+            const maxed = isItemMaxed(economy, item.id)
+            const canBuy = canPurchaseItem(economy, item.id)
+
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => buyItem(item.id)}
+                disabled={isGameOver || !canBuy}
+                className="shop-item"
+              >
+                <span className="shop-item__name">{item.name}</span>
+                <span className="shop-item__desc">{item.description}</span>
+                <span className="shop-item__meta">Cost ${item.cost} · {getItemProgress(economy, item.id)}</span>
+                <strong className="shop-item__action">{maxed ? 'Maxed' : 'Buy'}</strong>
+              </button>
+            )
+          })}
+        </div>
       </section>
 
       <button type="button" onClick={resetGame} className="restart">

--- a/src/gameUtils.js
+++ b/src/gameUtils.js
@@ -1,4 +1,7 @@
 export const GRID_SIZE = 20
+export const BASE_TICK_MS = 150
+export const SLOW_TIME_STEP_MS = 20
+export const GROWTH_PACK_SIZE = 2
 
 export const DIRECTIONS = {
   ArrowUp: { x: 0, y: -1 },
@@ -13,6 +16,51 @@ export const DIRECTIONS = {
   S: { x: 0, y: 1 },
   A: { x: -1, y: 0 },
   D: { x: 1, y: 0 }
+}
+
+export const SHOP_ITEM_IDS = {
+  coinMultiplier: 'coin_multiplier',
+  growthPack: 'growth_pack',
+  shield: 'shield',
+  slowTime: 'slow_time'
+}
+
+export const SHOP_ITEMS = [
+  {
+    id: SHOP_ITEM_IDS.coinMultiplier,
+    name: 'Coin Multiplier',
+    cost: 5,
+    description: 'Each bean gives +1 coin permanently.'
+  },
+  {
+    id: SHOP_ITEM_IDS.growthPack,
+    name: 'Growth Pack',
+    cost: 4,
+    description: `Gain ${GROWTH_PACK_SIZE} free growth ticks.`
+  },
+  {
+    id: SHOP_ITEM_IDS.shield,
+    name: 'Safety Shield',
+    cost: 6,
+    description: 'Negate one fatal collision.'
+  },
+  {
+    id: SHOP_ITEM_IDS.slowTime,
+    name: 'Slow Time',
+    cost: 7,
+    description: 'Reduce snake speed permanently.'
+  }
+]
+
+export const MAX_COIN_MULTIPLIER = 4
+export const MAX_SLOW_LEVEL = 4
+
+export const INITIAL_ECONOMY = {
+  money: 0,
+  coinMultiplier: 1,
+  pendingGrowth: 0,
+  shields: 0,
+  slowLevel: 0
 }
 
 export function isOppositeDirection(current, next) {
@@ -60,4 +108,59 @@ export function spawnFood(snake, gridSize = GRID_SIZE, randomFn = Math.random) {
       return { x, y }
     }
   }
+}
+
+export function getTickMs(slowLevel, baseTickMs = BASE_TICK_MS) {
+  return baseTickMs + slowLevel * SLOW_TIME_STEP_MS
+}
+
+export function canPurchaseItem(economy, itemId) {
+  const item = SHOP_ITEMS.find((entry) => entry.id === itemId)
+  if (!item || economy.money < item.cost) {
+    return false
+  }
+
+  if (itemId === SHOP_ITEM_IDS.coinMultiplier) {
+    return economy.coinMultiplier < MAX_COIN_MULTIPLIER
+  }
+
+  if (itemId === SHOP_ITEM_IDS.slowTime) {
+    return economy.slowLevel < MAX_SLOW_LEVEL
+  }
+
+  return true
+}
+
+export function purchaseItem(economy, itemId) {
+  if (!canPurchaseItem(economy, itemId)) {
+    return economy
+  }
+
+  const item = SHOP_ITEMS.find((entry) => entry.id === itemId)
+  const nextEconomy = {
+    ...economy,
+    money: economy.money - item.cost
+  }
+
+  if (itemId === SHOP_ITEM_IDS.coinMultiplier) {
+    nextEconomy.coinMultiplier += 1
+    return nextEconomy
+  }
+
+  if (itemId === SHOP_ITEM_IDS.growthPack) {
+    nextEconomy.pendingGrowth += GROWTH_PACK_SIZE
+    return nextEconomy
+  }
+
+  if (itemId === SHOP_ITEM_IDS.shield) {
+    nextEconomy.shields += 1
+    return nextEconomy
+  }
+
+  if (itemId === SHOP_ITEM_IDS.slowTime) {
+    nextEconomy.slowLevel += 1
+    return nextEconomy
+  }
+
+  return nextEconomy
 }

--- a/src/gameUtils.test.js
+++ b/src/gameUtils.test.js
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest'
-import { hasCollision, spawnFood, stepSnake } from './gameUtils'
+import {
+  INITIAL_ECONOMY,
+  SHOP_ITEM_IDS,
+  canPurchaseItem,
+  getTickMs,
+  hasCollision,
+  purchaseItem,
+  spawnFood,
+  stepSnake
+} from './gameUtils'
 
 describe('stepSnake', () => {
   it('moves forward without growth', () => {
@@ -72,5 +81,32 @@ describe('spawnFood', () => {
   it('returns null when board is full', () => {
     const snake = [{ x: 0, y: 0 }]
     expect(spawnFood(snake, 1)).toBeNull()
+  })
+})
+
+describe('economy helpers', () => {
+  it('blocks purchase when money is insufficient', () => {
+    const economy = { ...INITIAL_ECONOMY, money: 3 }
+    expect(canPurchaseItem(economy, SHOP_ITEM_IDS.shield)).toBe(false)
+  })
+
+  it('applies growth pack purchase', () => {
+    const economy = { ...INITIAL_ECONOMY, money: 10 }
+    const next = purchaseItem(economy, SHOP_ITEM_IDS.growthPack)
+
+    expect(next.money).toBe(6)
+    expect(next.pendingGrowth).toBe(2)
+  })
+
+  it('caps multiplier purchases at max level', () => {
+    const economy = { ...INITIAL_ECONOMY, money: 99, coinMultiplier: 4 }
+    const next = purchaseItem(economy, SHOP_ITEM_IDS.coinMultiplier)
+
+    expect(next).toBe(economy)
+  })
+
+  it('converts slow level to tick ms', () => {
+    expect(getTickMs(0)).toBe(150)
+    expect(getTickMs(3)).toBe(210)
   })
 })


### PR DESCRIPTION
## Summary\n- convert each eaten bean into money during the current run\n- add an in-game shop with four purchasable upgrades: coin multiplier, growth pack, safety shield, and slow-time\n- show active buff state and current money/speed in the HUD\n- add utility tests for economy purchase and tick-speed behavior\n\n## Why\nIssue #4 requests turning eaten beans into money and allowing purchases mid-game with different snake-enhancing buffs/mechanics.\n\nCloses #4\n\n## Validation\n- npm test\n- npm run build