### PR TITLE
feat: add basic sound effects for snake gameplay

### DIFF
--- a/openspec/changes/add-sound-effects/.openspec.yaml
+++ b/openspec/changes/add-sound-effects/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-09

--- a/openspec/changes/add-sound-effects/design.md
+++ b/openspec/changes/add-sound-effects/design.md
@@ -1,0 +1,43 @@
+## Context
+
+当前游戏主逻辑集中在 `src/App.jsx` 的 `setInterval` 驱动循环中，吃食物、碰撞、复位等事件都已在同一状态机内可识别。项目未引入任何音频资源或音频库，因此最简方案是复用浏览器 Web Audio API，以代码方式生成短促提示音。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 为开始、吃食物、碰撞、结束事件提供可感知的短音效。
+- 以低耦合方式接入，避免污染核心游戏算法。
+- 提供可测试的事件到音效映射逻辑。
+
+**Non-Goals:**
+- 不实现复杂背景音乐或多轨混音。
+- 不新增音量滑块、音效包下载、持久化配置。
+- 不处理跨页面全局音频管理。
+
+## Decisions
+
+1. 新建 `src/soundEffects.js` 作为音效模块，暴露：
+- 事件常量（start/eat/collision/gameOver）
+- `createSoundEffects()` 工厂（便于测试注入假 `AudioContext`）
+- `play(event)` 与 `setMuted(boolean)` 等方法
+
+Rationale: 将音频细节从 `App.jsx` 抽离，降低组件复杂度，并方便单测验证映射。
+
+2. 使用 Web Audio API 合成提示音，而非引入音频文件：
+- 每个事件定义频率、时长、波形、包络
+- 通过 `OscillatorNode + GainNode` 快速播放
+
+Rationale: 无额外资源管理，提交体积小，跨环境兼容性高。
+
+3. 仅在明确事件节点触发声音：
+- 组件挂载后（或首次开始）触发 `start`
+- 吃到食物触发 `eat`
+- 检测到碰撞时触发 `collision`，若导致失败再触发 `gameOver`
+
+Rationale: 保证音效与玩家感知事件一致，避免重复和噪音。
+
+## Risks / Trade-offs
+
+- [浏览器自动播放策略可能阻止首次播放] → 在首次用户按键时恢复 `AudioContext`，并在失败时静默降级。
+- [高频事件导致声音重叠失真] → 每次事件使用短时包络并限制持续时间，确保即使重叠也可接受。
+- [测试环境缺少真实 AudioContext] → 使用可注入工厂和 mock 对象测试，不依赖真实浏览器音频实现。

--- a/openspec/changes/add-sound-effects/proposal.md
+++ b/openspec/changes/add-sound-effects/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+当前贪吃蛇游戏只有视觉反馈，缺少声音提示，导致吃到食物、碰撞、开局/结束这些关键时刻反馈不够明确。增加基础音效可以提升操作反馈和游戏沉浸感，且实现范围小、收益高。
+
+## What Changes
+
+- 为游戏增加基础事件音效：开始、吃到食物、碰撞、游戏结束。
+- 使用浏览器原生 Web Audio API 生成轻量音效，避免引入额外音频文件和依赖。
+- 增加一个集中式音效控制器，负责初始化、播放与静音开关。
+- 在 `App` 的游戏状态流转中接入音效触发，确保事件与声音一一对应。
+- 增加针对音效映射和触发流程的单元测试。
+
+## Capabilities
+
+### New Capabilities
+- `game-sound-effects`: 提供蛇游戏核心事件的基础音效反馈与可控播放行为。
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected code: `src/App.jsx`, 新增 `src/soundEffects.js`，新增或修改测试文件。
+- APIs: 使用浏览器 `AudioContext` / `OscillatorNode` / `GainNode`。
+- Dependencies: 无新增第三方依赖。
+- UX: 增强关键游戏事件反馈，默认启用音效。

--- a/openspec/changes/add-sound-effects/specs/game-sound-effects/spec.md
+++ b/openspec/changes/add-sound-effects/specs/game-sound-effects/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Core game events SHALL trigger audio cues
+The game SHALL provide short sound effects for key gameplay events so players can identify state changes without relying only on visual feedback.
+
+#### Scenario: Game start cue
+- **WHEN** a new game session starts
+- **THEN** the system plays the start sound effect once
+
+#### Scenario: Food collected cue
+- **WHEN** the snake head reaches the current food position
+- **THEN** the system plays the food collection sound effect
+
+#### Scenario: Collision cue
+- **WHEN** the snake collides with a wall or itself
+- **THEN** the system plays the collision sound effect
+
+#### Scenario: Game over cue
+- **WHEN** a collision ends the session
+- **THEN** the system plays the game-over sound effect
+
+### Requirement: Sound playback SHALL fail safely
+If audio playback is unavailable, blocked, or errors during runtime, the game SHALL continue running without breaking gameplay.
+
+#### Scenario: Audio unavailable
+- **WHEN** the browser does not provide a usable audio context
+- **THEN** the game continues without throwing unhandled runtime errors
+
+#### Scenario: Audio resume rejected
+- **WHEN** the audio context resume operation is rejected by browser policy
+- **THEN** gameplay logic remains unaffected and no crash occurs

--- a/openspec/changes/add-sound-effects/tasks.md
+++ b/openspec/changes/add-sound-effects/tasks.md
@@ -1,0 +1,14 @@
+## 1. Audio module and event mapping
+
+- [x] 1.1 Create `src/soundEffects.js` with Web Audio API based effect definitions for `start`, `eat`, `collision`, and `gameOver`
+- [x] 1.2 Add safe guards and graceful fallback when `AudioContext` is unavailable or resume/play fails
+
+## 2. Game integration
+
+- [x] 2.1 Integrate sound effect controller into `src/App.jsx` and trigger effects at start, food collection, collision, and game-over transitions
+- [x] 2.2 Ensure sound triggering avoids duplicate playback in a single tick and does not alter existing game rules
+
+## 3. Validation
+
+- [x] 3.1 Add unit tests for sound configuration / event mapping and safety behavior
+- [x] 3.2 Run project test suite and build to verify no regressions

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import {
   spawnFood,
   stepSnake
 } from './gameUtils'
+import { SOUND_EVENTS, createSoundEffects } from './soundEffects'
 
 extend({ ThreeOrbitControls })
 
@@ -248,8 +249,33 @@ function App() {
   const [score, setScore] = useState(0)
   const [isGameOver, setIsGameOver] = useState(false)
   const [economy, setEconomy] = useState(INITIAL_ECONOMY)
+  const soundEffectsRef = useRef(null)
+  const startCuePlayedRef = useRef(false)
 
   const tickMs = useMemo(() => getTickMs(economy.slowLevel), [economy.slowLevel])
+
+  useEffect(() => {
+    soundEffectsRef.current = createSoundEffects()
+
+    return () => {
+      soundEffectsRef.current?.destroy()
+      soundEffectsRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isGameOver) {
+      startCuePlayedRef.current = false
+      return
+    }
+
+    if (startCuePlayedRef.current) {
+      return
+    }
+
+    soundEffectsRef.current?.play(SOUND_EVENTS.start)
+    startCuePlayedRef.current = true
+  }, [isGameOver])
 
   useEffect(() => {
     function onKeyDown(event) {
@@ -257,6 +283,8 @@ function App() {
       if (!next || isGameOver) {
         return
       }
+
+      soundEffectsRef.current?.resume()
 
       setQueuedDirection((currentQueued) => {
         if (isOppositeDirection(direction, next) || isOppositeDirection(currentQueued, next)) {
@@ -291,11 +319,14 @@ function App() {
         const nextSnake = stepSnake(currentSnake, activeDirection, shouldGrow)
 
         if (hasCollision(nextSnake, GRID_SIZE)) {
+          soundEffectsRef.current?.play(SOUND_EVENTS.collision)
+
           if (economy.shields > 0) {
             setEconomy((value) => ({ ...value, shields: Math.max(0, value.shields - 1) }))
             return currentSnake
           }
 
+          soundEffectsRef.current?.play(SOUND_EVENTS.gameOver)
           setIsGameOver(true)
           return currentSnake
         }
@@ -305,6 +336,7 @@ function App() {
         }
 
         if (willEatFood) {
+          soundEffectsRef.current?.play(SOUND_EVENTS.eat)
           setScore((value) => value + 1)
           setEconomy((value) => ({ ...value, money: value.money + value.coinMultiplier }))
           setFood(spawnFood(nextSnake, GRID_SIZE))
@@ -341,6 +373,8 @@ function App() {
   }
 
   function resetGame() {
+    const shouldPlayStartImmediately = !isGameOver
+
     setSnake(INITIAL_SNAKE)
     setDirection(INITIAL_DIRECTION)
     setQueuedDirection(INITIAL_DIRECTION)
@@ -348,6 +382,13 @@ function App() {
     setScore(0)
     setEconomy(INITIAL_ECONOMY)
     setIsGameOver(false)
+
+    if (shouldPlayStartImmediately) {
+      soundEffectsRef.current?.play(SOUND_EVENTS.start)
+      startCuePlayedRef.current = true
+    } else {
+      startCuePlayedRef.current = false
+    }
   }
 
   return (

--- a/src/soundEffects.js
+++ b/src/soundEffects.js
@@ -1,0 +1,175 @@
+export const SOUND_EVENTS = Object.freeze({
+  start: 'start',
+  eat: 'eat',
+  collision: 'collision',
+  gameOver: 'gameOver'
+})
+
+export const SOUND_EFFECTS = Object.freeze({
+  [SOUND_EVENTS.start]: {
+    type: 'triangle',
+    frequency: 440,
+    frequencyEnd: 620,
+    attack: 0.01,
+    duration: 0.14,
+    gain: 0.06
+  },
+  [SOUND_EVENTS.eat]: {
+    type: 'sine',
+    frequency: 780,
+    frequencyEnd: 980,
+    attack: 0.008,
+    duration: 0.1,
+    gain: 0.07
+  },
+  [SOUND_EVENTS.collision]: {
+    type: 'sawtooth',
+    frequency: 220,
+    frequencyEnd: 120,
+    attack: 0.005,
+    duration: 0.18,
+    gain: 0.08
+  },
+  [SOUND_EVENTS.gameOver]: {
+    type: 'square',
+    frequency: 180,
+    frequencyEnd: 72,
+    attack: 0.005,
+    duration: 0.24,
+    gain: 0.09
+  }
+})
+
+function getAudioContextConstructor() {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  return window.AudioContext ?? window.webkitAudioContext ?? null
+}
+
+export function createSoundEffects({ audioContextFactory } = {}) {
+  let context = null
+  let disabled = false
+  let muted = false
+
+  function getContext() {
+    if (disabled) {
+      return null
+    }
+
+    if (context) {
+      return context
+    }
+
+    try {
+      if (audioContextFactory) {
+        context = audioContextFactory()
+      } else {
+        const AudioContextConstructor = getAudioContextConstructor()
+        context = AudioContextConstructor ? new AudioContextConstructor() : null
+      }
+    } catch {
+      context = null
+    }
+
+    if (!context) {
+      disabled = true
+      return null
+    }
+
+    return context
+  }
+
+  function resume() {
+    const activeContext = getContext()
+    if (!activeContext || typeof activeContext.resume !== 'function') {
+      return
+    }
+
+    try {
+      const maybePromise = activeContext.resume()
+      if (maybePromise && typeof maybePromise.catch === 'function') {
+        maybePromise.catch(() => {})
+      }
+    } catch {
+      // Keep gameplay running even if resume fails.
+    }
+  }
+
+  function play(eventName) {
+    if (muted) {
+      return false
+    }
+
+    const effect = SOUND_EFFECTS[eventName]
+    if (!effect) {
+      return false
+    }
+
+    const activeContext = getContext()
+    if (!activeContext) {
+      return false
+    }
+
+    resume()
+
+    try {
+      const now = activeContext.currentTime ?? 0
+      const oscillator = activeContext.createOscillator()
+      const gainNode = activeContext.createGain()
+
+      oscillator.type = effect.type
+      oscillator.frequency.setValueAtTime(effect.frequency, now)
+      oscillator.frequency.linearRampToValueAtTime(effect.frequencyEnd, now + effect.duration)
+
+      gainNode.gain.setValueAtTime(0.0001, now)
+      gainNode.gain.exponentialRampToValueAtTime(effect.gain, now + effect.attack)
+      gainNode.gain.exponentialRampToValueAtTime(0.0001, now + effect.duration)
+
+      oscillator.connect(gainNode)
+      gainNode.connect(activeContext.destination)
+
+      oscillator.start(now)
+      oscillator.stop(now + effect.duration)
+
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  function setMuted(value) {
+    muted = Boolean(value)
+  }
+
+  function isMuted() {
+    return muted
+  }
+
+  function destroy() {
+    if (!context || typeof context.close !== 'function') {
+      context = null
+      return
+    }
+
+    try {
+      const maybePromise = context.close()
+      if (maybePromise && typeof maybePromise.catch === 'function') {
+        maybePromise.catch(() => {})
+      }
+    } catch {
+      // Ignore close failures and release local reference.
+    }
+
+    context = null
+  }
+
+  return {
+    destroy,
+    isMuted,
+    play,
+    resume,
+    setMuted
+  }
+}

--- a/src/soundEffects.test.js
+++ b/src/soundEffects.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+import { SOUND_EFFECTS, SOUND_EVENTS, createSoundEffects } from './soundEffects'
+
+function createFakeAudioContext() {
+  const frequency = {
+    linearRampToValueAtTime: vi.fn(),
+    setValueAtTime: vi.fn()
+  }
+  const oscillator = {
+    connect: vi.fn(),
+    frequency,
+    start: vi.fn(),
+    stop: vi.fn(),
+    type: 'sine'
+  }
+  const gain = {
+    exponentialRampToValueAtTime: vi.fn(),
+    setValueAtTime: vi.fn()
+  }
+  const gainNode = {
+    connect: vi.fn(),
+    gain
+  }
+
+  return {
+    close: vi.fn().mockResolvedValue(undefined),
+    createGain: vi.fn(() => gainNode),
+    createOscillator: vi.fn(() => oscillator),
+    currentTime: 2,
+    destination: { label: 'destination' },
+    gainNode,
+    oscillator,
+    resume: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+describe('createSoundEffects', () => {
+  it('plays configured sound for a known event', () => {
+    const context = createFakeAudioContext()
+    const soundEffects = createSoundEffects({
+      audioContextFactory: () => context
+    })
+
+    const result = soundEffects.play(SOUND_EVENTS.eat)
+
+    expect(result).toBe(true)
+    expect(context.resume).toHaveBeenCalledTimes(1)
+    expect(context.createOscillator).toHaveBeenCalledTimes(1)
+    expect(context.createGain).toHaveBeenCalledTimes(1)
+    expect(context.oscillator.type).toBe(SOUND_EFFECTS[SOUND_EVENTS.eat].type)
+    expect(context.oscillator.frequency.setValueAtTime).toHaveBeenCalledWith(
+      SOUND_EFFECTS[SOUND_EVENTS.eat].frequency,
+      context.currentTime
+    )
+    expect(context.oscillator.start).toHaveBeenCalledWith(context.currentTime)
+  })
+
+  it('returns false safely when audio context is unavailable', () => {
+    const soundEffects = createSoundEffects({
+      audioContextFactory: () => null
+    })
+
+    expect(() => soundEffects.resume()).not.toThrow()
+    expect(soundEffects.play(SOUND_EVENTS.start)).toBe(false)
+    expect(soundEffects.play('unknown-event')).toBe(false)
+    expect(() => soundEffects.destroy()).not.toThrow()
+  })
+
+  it('handles runtime audio errors without throwing', () => {
+    const context = createFakeAudioContext()
+    context.resume = vi.fn().mockRejectedValue(new Error('blocked'))
+    context.createOscillator = vi.fn(() => {
+      throw new Error('oscillator failed')
+    })
+
+    const soundEffects = createSoundEffects({
+      audioContextFactory: () => context
+    })
+
+    expect(() => soundEffects.resume()).not.toThrow()
+    expect(() => soundEffects.play(SOUND_EVENTS.collision)).not.toThrow()
+    expect(soundEffects.play(SOUND_EVENTS.collision)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add a Web Audio based sound effects module for start, eat, collision, and game-over events
- integrate sound triggers into the game loop and restart/start transitions in `src/App.jsx`
- add unit tests for sound event playback mapping and graceful fallback behavior
- include OpenSpec change artifacts for `add-sound-effects`

## Why
This adds immediate audio feedback for core gameplay events so players can detect key state transitions without relying only on visuals.

## Validation
- npm test
- npm run build

Closes #9
