### PR TITLE
feat: 增加贪吃蛇背景音乐播放/暂停并支持与音效共存

### DIFF
--- a/openspec/changes/archive/2026-03-09-add-background-music/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-09-add-background-music/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-09

--- a/openspec/changes/archive/2026-03-09-add-background-music/design.md
+++ b/openspec/changes/archive/2026-03-09-add-background-music/design.md
@@ -1,0 +1,36 @@
+## Context
+
+The game currently has no audio layer, while issue #10 requires background music with play/pause controls and compatibility with gameplay sound effects. The app is a single React page with game loop logic in `App.jsx`, so audio control should remain local to the client and not change game rules or persistence.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add background music that can be started and paused by the player.
+- Ensure background music and gameplay sound effects can play concurrently.
+- Keep audio implementation lightweight with no server dependency.
+- Cover new audio-state behavior with unit tests where feasible.
+
+**Non-Goals:**
+- Advanced mixer settings (volume sliders, track selection, mute groups).
+- Network audio streaming or user-uploaded music.
+- Full browser compatibility fallback for very old audio APIs.
+
+## Decisions
+
+1. **Use a small Web Audio engine instead of static media files**
+   - Rationale: Avoid repository bloat and external licensing concerns while delivering immediate background music and effects.
+   - Alternative considered: shipping mp3/ogg assets. Rejected for higher asset management overhead in this small project.
+
+2. **Separate background music state from effect triggers**
+   - Rationale: Background music should toggle independently, while effects fire on game events (eat/collision). This directly satisfies coexistence.
+   - Alternative considered: one shared playback channel. Rejected because effects could interrupt background music.
+
+3. **Drive effect triggers from existing game-loop events**
+   - Rationale: Eat and game-over transitions already exist in the loop, so adding effect triggers there keeps behavior deterministic.
+   - Alternative considered: separate observer/event bus. Rejected as unnecessary complexity.
+
+## Risks / Trade-offs
+
+- **[Risk] Browser autoplay restrictions block audio until user interaction** → Mitigation: lazily create/resume audio context from keyboard/button interactions.
+- **[Risk] Added logic in game loop increases coupling to UI** → Mitigation: move audio synthesis details into a dedicated utility module and keep App integration thin.
+- **[Trade-off] Synthesized tones sound simpler than recorded tracks** → Accepted for fast implementation and zero asset maintenance.

--- a/openspec/changes/archive/2026-03-09-add-background-music/proposal.md
+++ b/openspec/changes/archive/2026-03-09-add-background-music/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Current gameplay only includes short sound effects, so the game feels sparse during longer sessions. Adding optional background music improves immersion while preserving existing effect feedback.
+
+## What Changes
+
+- Add looped background music playback during active gameplay.
+- Add an in-game control to play/pause background music at runtime.
+- Keep collision/eat effects working independently from background music.
+- Add tests for new audio-state behavior and non-regression of effects behavior.
+
+## Capabilities
+
+### New Capabilities
+- `background-music-control`: Provide background music playback with user play/pause control and independent coexistence with sound effects.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected code: `src/App.jsx`, `src/gameUtils.js`, and related styling in `src/App.css`.
+- New static asset: background music audio file under `src/assets/`.
+- Tests: update/add unit tests for audio state handling in `src/gameUtils.test.js` or new test files.

--- a/openspec/changes/archive/2026-03-09-add-background-music/specs/background-music-control/spec.md
+++ b/openspec/changes/archive/2026-03-09-add-background-music/specs/background-music-control/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Background music can be toggled during gameplay
+The system SHALL provide a control that lets players start and pause background music at runtime without reloading the game.
+
+#### Scenario: Player starts background music
+- **WHEN** the player activates the music control while music is paused
+- **THEN** the game starts looped background music playback
+
+#### Scenario: Player pauses background music
+- **WHEN** the player activates the music control while music is playing
+- **THEN** the game pauses background music playback and keeps gameplay running
+
+### Requirement: Background music coexists with gameplay sound effects
+The system SHALL play gameplay sound effects on top of background music without stopping or replacing the background track.
+
+#### Scenario: Eat effect plays while music is running
+- **WHEN** the snake eats food while background music is playing
+- **THEN** the eat sound effect is played and background music continues
+
+#### Scenario: Game-over effect plays while music is running
+- **WHEN** a fatal collision happens while background music is playing
+- **THEN** the game-over sound effect is played and background music state remains unchanged

--- a/openspec/changes/archive/2026-03-09-add-background-music/tasks.md
+++ b/openspec/changes/archive/2026-03-09-add-background-music/tasks.md
@@ -1,0 +1,14 @@
+## 1. Audio Engine
+
+- [x] 1.1 Add a client-side audio utility that can play/pause looped background music.
+- [x] 1.2 Add one-shot gameplay sound effects that can play while background music is active.
+
+## 2. UI and Game Integration
+
+- [x] 2.1 Add a music toggle control in the game UI with clear play/pause state.
+- [x] 2.2 Trigger eat/game-over sound effects from game-loop events without breaking existing gameplay logic.
+
+## 3. Verification
+
+- [x] 3.1 Add or update unit tests for new audio-state helper behavior.
+- [x] 3.2 Run project tests/build to verify no regressions.

--- a/openspec/specs/background-music-control/spec.md
+++ b/openspec/specs/background-music-control/spec.md
@@ -1,0 +1,27 @@
+# background-music-control Specification
+
+## Purpose
+TBD - created by archiving change add-background-music. Update Purpose after archive.
+## Requirements
+### Requirement: Background music can be toggled during gameplay
+The system SHALL provide a control that lets players start and pause background music at runtime without reloading the game.
+
+#### Scenario: Player starts background music
+- **WHEN** the player activates the music control while music is paused
+- **THEN** the game starts looped background music playback
+
+#### Scenario: Player pauses background music
+- **WHEN** the player activates the music control while music is playing
+- **THEN** the game pauses background music playback and keeps gameplay running
+
+### Requirement: Background music coexists with gameplay sound effects
+The system SHALL play gameplay sound effects on top of background music without stopping or replacing the background track.
+
+#### Scenario: Eat effect plays while music is running
+- **WHEN** the snake eats food while background music is playing
+- **THEN** the eat sound effect is played and background music continues
+
+#### Scenario: Game-over effect plays while music is running
+- **WHEN** a fatal collision happens while background music is playing
+- **THEN** the game-over sound effect is played and background music state remains unchanged
+

--- a/src/App.css
+++ b/src/App.css
@@ -69,6 +69,29 @@ h2 {
   backdrop-filter: blur(2px);
 }
 
+.audio-toggle {
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: border-color 160ms ease, transform 160ms ease;
+}
+
+.audio-toggle:hover {
+  border-color: #22c55e;
+  transform: translateY(-1px);
+}
+
+.audio-toggle[aria-pressed='true'] {
+  background: linear-gradient(90deg, #166534, #22c55e);
+  color: #052e16;
+  border-color: transparent;
+}
+
 .buffs {
   width: min(520px, 100%);
   display: grid;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { Canvas, extend, useFrame, useThree } from '@react-three/fiber'
 import { OrbitControls as ThreeOrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import './App.css'
+import { createAudioEngine, togglePlaybackState } from './audioEngine'
 import {
   DIRECTIONS,
   GRID_SIZE,
@@ -248,8 +249,49 @@ function App() {
   const [score, setScore] = useState(0)
   const [isGameOver, setIsGameOver] = useState(false)
   const [economy, setEconomy] = useState(INITIAL_ECONOMY)
+  const [isMusicPlaying, setIsMusicPlaying] = useState(false)
+  const audioEngineRef = useRef(null)
 
   const tickMs = useMemo(() => getTickMs(economy.slowLevel), [economy.slowLevel])
+
+  function getAudioEngine() {
+    if (!audioEngineRef.current) {
+      audioEngineRef.current = createAudioEngine()
+    }
+
+    return audioEngineRef.current
+  }
+
+  function unlockAudio() {
+    const engine = getAudioEngine()
+    void engine.resume()
+  }
+
+  function toggleMusic() {
+    getAudioEngine()
+    setIsMusicPlaying((current) => togglePlaybackState(current))
+  }
+
+  useEffect(() => {
+    const engine = audioEngineRef.current
+    if (!engine) {
+      return
+    }
+
+    if (isMusicPlaying) {
+      void engine.resume().then(() => {
+        engine.startMusic()
+      })
+      return
+    }
+
+    engine.stopMusic()
+  }, [isMusicPlaying])
+
+  useEffect(() => () => {
+    audioEngineRef.current?.dispose()
+    audioEngineRef.current = null
+  }, [])
 
   useEffect(() => {
     function onKeyDown(event) {
@@ -257,6 +299,8 @@ function App() {
       if (!next || isGameOver) {
         return
       }
+
+      unlockAudio()
 
       setQueuedDirection((currentQueued) => {
         if (isOppositeDirection(direction, next) || isOppositeDirection(currentQueued, next)) {
@@ -296,6 +340,7 @@ function App() {
             return currentSnake
           }
 
+          audioEngineRef.current?.playGameOverEffect()
           setIsGameOver(true)
           return currentSnake
         }
@@ -305,6 +350,7 @@ function App() {
         }
 
         if (willEatFood) {
+          audioEngineRef.current?.playEatEffect()
           setScore((value) => value + 1)
           setEconomy((value) => ({ ...value, money: value.money + value.coinMultiplier }))
           setFood(spawnFood(nextSnake, GRID_SIZE))
@@ -381,6 +427,15 @@ function App() {
       <div className="hud">
         <span>Score: {score}</span>
         <span>Occupied: {occupiedCellCount}</span>
+        <span>Music: {isMusicPlaying ? 'On' : 'Off'}</span>
+        <button
+          type="button"
+          onClick={toggleMusic}
+          className="audio-toggle"
+          aria-pressed={isMusicPlaying}
+        >
+          {isMusicPlaying ? 'Pause Music' : 'Play Music'}
+        </button>
         {isGameOver && <strong className="game-over">Game Over</strong>}
       </div>
 

--- a/src/audioEngine.js
+++ b/src/audioEngine.js
@@ -1,0 +1,170 @@
+const BGM_NOTES = [261.63, 329.63, 392, 329.63, 523.25, 392, 329.63, 293.66]
+const BGM_NOTE_DURATION_SECONDS = 0.22
+const BGM_NOTE_INTERVAL_MS = 260
+
+export function togglePlaybackState(isPlaying) {
+  return !isPlaying
+}
+
+export function getNextLoopIndex(currentIndex, total = BGM_NOTES.length) {
+  if (total <= 0) {
+    return 0
+  }
+
+  return (currentIndex + 1) % total
+}
+
+function createNoopAudioEngine() {
+  return {
+    async resume() {},
+    startMusic() {},
+    stopMusic() {},
+    playEatEffect() {},
+    playGameOverEffect() {},
+    dispose() {}
+  }
+}
+
+function playTone(context, destination, config) {
+  if (!context || !destination) {
+    return
+  }
+
+  const {
+    frequency,
+    type,
+    durationSeconds,
+    peakGain,
+    startAt = context.currentTime
+  } = config
+  const oscillator = context.createOscillator()
+  const gainNode = context.createGain()
+
+  oscillator.type = type
+  oscillator.frequency.setValueAtTime(frequency, startAt)
+
+  gainNode.gain.setValueAtTime(0.0001, startAt)
+  gainNode.gain.exponentialRampToValueAtTime(peakGain, startAt + 0.02)
+  gainNode.gain.exponentialRampToValueAtTime(0.0001, startAt + durationSeconds)
+
+  oscillator.connect(gainNode)
+  gainNode.connect(destination)
+
+  oscillator.start(startAt)
+  oscillator.stop(startAt + durationSeconds + 0.03)
+}
+
+export function createAudioEngine() {
+  if (typeof window === 'undefined') {
+    return createNoopAudioEngine()
+  }
+
+  const AudioContextCtor = window.AudioContext || window.webkitAudioContext
+  if (!AudioContextCtor) {
+    return createNoopAudioEngine()
+  }
+
+  const context = new AudioContextCtor()
+  const masterGain = context.createGain()
+  masterGain.gain.value = 0.33
+  masterGain.connect(context.destination)
+
+  const musicGain = context.createGain()
+  musicGain.gain.value = 0.17
+  musicGain.connect(masterGain)
+
+  const effectGain = context.createGain()
+  effectGain.gain.value = 0.26
+  effectGain.connect(masterGain)
+
+  let bgmLoopIndex = 0
+  let bgmTimerId = null
+
+  function playBackgroundNote() {
+    playTone(context, musicGain, {
+      frequency: BGM_NOTES[bgmLoopIndex],
+      type: 'triangle',
+      durationSeconds: BGM_NOTE_DURATION_SECONDS,
+      peakGain: 0.08
+    })
+
+    bgmLoopIndex = getNextLoopIndex(bgmLoopIndex)
+  }
+
+  function startMusic() {
+    if (bgmTimerId !== null) {
+      return
+    }
+
+    playBackgroundNote()
+    bgmTimerId = window.setInterval(playBackgroundNote, BGM_NOTE_INTERVAL_MS)
+  }
+
+  function stopMusic() {
+    if (bgmTimerId === null) {
+      return
+    }
+
+    window.clearInterval(bgmTimerId)
+    bgmTimerId = null
+  }
+
+  async function resume() {
+    if (context.state === 'suspended') {
+      await context.resume()
+    }
+  }
+
+  function playEatEffect() {
+    const now = context.currentTime
+    playTone(context, effectGain, {
+      frequency: 659.25,
+      type: 'square',
+      durationSeconds: 0.09,
+      peakGain: 0.05,
+      startAt: now
+    })
+    playTone(context, effectGain, {
+      frequency: 783.99,
+      type: 'square',
+      durationSeconds: 0.08,
+      peakGain: 0.04,
+      startAt: now + 0.08
+    })
+  }
+
+  function playGameOverEffect() {
+    const now = context.currentTime
+    playTone(context, effectGain, {
+      frequency: 311.13,
+      type: 'sawtooth',
+      durationSeconds: 0.16,
+      peakGain: 0.055,
+      startAt: now
+    })
+    playTone(context, effectGain, {
+      frequency: 233.08,
+      type: 'sawtooth',
+      durationSeconds: 0.2,
+      peakGain: 0.055,
+      startAt: now + 0.12
+    })
+  }
+
+  function dispose() {
+    stopMusic()
+    masterGain.disconnect()
+    musicGain.disconnect()
+    effectGain.disconnect()
+    void context.close()
+  }
+
+  return {
+    resume,
+    startMusic,
+    stopMusic,
+    playEatEffect,
+    playGameOverEffect,
+    dispose
+  }
+}

--- a/src/audioEngine.test.js
+++ b/src/audioEngine.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { getNextLoopIndex, togglePlaybackState } from './audioEngine'
+
+describe('togglePlaybackState', () => {
+  it('switches paused to playing', () => {
+    expect(togglePlaybackState(false)).toBe(true)
+  })
+
+  it('switches playing to paused', () => {
+    expect(togglePlaybackState(true)).toBe(false)
+  })
+})
+
+describe('getNextLoopIndex', () => {
+  it('advances and wraps with total length', () => {
+    expect(getNextLoopIndex(0, 4)).toBe(1)
+    expect(getNextLoopIndex(3, 4)).toBe(0)
+  })
+
+  it('returns zero when total is not positive', () => {
+    expect(getNextLoopIndex(9, 0)).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary\n- add a Web Audio based engine for looped background music playback and pause/resume\n- add eat/game-over one-shot sound effects that can play while background music is active\n- add UI music toggle control and audio state indicator in the HUD\n- add tests for audio state helpers and complete OpenSpec change archival\n\n## Validation\n- npm test\n- npm run build\n- openspec validate --specs --strict\n\nCloses #10